### PR TITLE
Fix Source URL in Pages static output

### DIFF
--- a/build_reports.sh
+++ b/build_reports.sh
@@ -5,7 +5,13 @@ go tool cover -html=cover.out -o coverage.html
 
 mv coverage.html public/coverage.html
 
-godoc -url "http://localhost:6060/pkg/$(go list -m)" | egrep -v 'using module mode; GOMOD=' | sed 's+/lib/godoc/++g' | sed 's+href="/src/+href="https://+g' |sed 's+href="https://github.com/bja2142/sshproxyplus/+href="https://github.com/bja2142/sshproxyplus/blob/main/+g' | sed 's+<body>+<body><h2><center><a href="coverage.html">Coverage Report</a></center></h2>+' | sed 's+href="/pkg/+target="_new" href="https://pkg.go.dev/+g' > public/index.html
+godoc -url "http://localhost:6060/pkg/$(go list -m)" |
+       	egrep -v 'using module mode; GOMOD=' | 
+	sed 's+/lib/godoc/++g' | 
+	sed 's+href="/src/+href="https://+g' |
+	sed 's+href="https://github.com/bja2142/sshproxyplus/+href="https://github.com/bja2142/sshproxyplus/blob/main/+g' | 
+	sed 's+<body>+<body><h2><center><a href="coverage.html">Coverage Report</a></center></h2>+' | 
+	sed 's+href="/pkg/+target="_new" href="https://pkg.go.dev/+g' > public/index.html
 godoc -url "http://localhost:6060/lib/godoc/style.css" > public/style.css
 godoc -url "http://localhost:6060/lib/godoc/jquery.js" > public/jquery.js
 godoc -url "http://localhost:6060/lib/godoc/godocs.js" > public/godocs.js

--- a/build_reports.sh
+++ b/build_reports.sh
@@ -5,7 +5,7 @@ go tool cover -html=cover.out -o coverage.html
 
 mv coverage.html public/coverage.html
 
-godoc -url "http://localhost:6060/pkg/$(go list -m)" | egrep -v 'using module mode; GOMOD=' | sed 's+/lib/godoc/++g' | sed 's+href="/src/+href="http://+g' | sed 's+<body>+<body><h2><center><a href="coverage.html">Coverage Report</a></center></h2>+' | sed 's+href="/pkg/+target="_new" href="https://pkg.go.dev/+g' > public/index.html
+godoc -url "http://localhost:6060/pkg/$(go list -m)" | egrep -v 'using module mode; GOMOD=' | sed 's+/lib/godoc/++g' | sed 's+href="/src/+href="https://+g' |sed 's+href="https://github.com/bja2142/sshproxyplus/+href="https://github.com/bja2142/sshproxyplus/blob/main/+g' | sed 's+<body>+<body><h2><center><a href="coverage.html">Coverage Report</a></center></h2>+' | sed 's+href="/pkg/+target="_new" href="https://pkg.go.dev/+g' > public/index.html
 godoc -url "http://localhost:6060/lib/godoc/style.css" > public/style.css
 godoc -url "http://localhost:6060/lib/godoc/jquery.js" > public/jquery.js
 godoc -url "http://localhost:6060/lib/godoc/godocs.js" > public/godocs.js


### PR DESCRIPTION
This fixes a bug in which the source code links were pointing to the wrong URL on GitHub. 